### PR TITLE
Improvements to MIDI sending

### DIFF
--- a/foulplay.lua
+++ b/foulplay.lua
@@ -337,7 +337,7 @@ function init()
     params:add_option(i.."_send_midi", i..": send midi", {"no", "yes"}, 1)
     params:add_option(i.."_midi_target", i..": device", midi_device_names, 1)
     params:add_number(i.."_midi_chan", i..": midi chan", 1, 16, 1)
-    params:add_number(i.."_midi_note", i..": midi note", 0, 127, 0, midi_note_formatter)
+    params:add_number(i.."_midi_note", i..": midi note", 0, 127, 60, midi_note_formatter)
   end
   params:add_separator('crow sends')
   for i = 1, 8 do

--- a/foulplay.lua
+++ b/foulplay.lua
@@ -213,6 +213,12 @@ local function reer(i)
   end
 end
 
+local function send_midi_note_on(i)
+  if params:get(i .. "_send_midi") == 2 then
+    m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
+    note_off_queue[i] = 1
+  end
+end
 
 local function trig()
   -- mute state is ignored for trigger logics
@@ -224,10 +230,7 @@ local function trig()
         if i <= 4 and params:get(i .. "_send_crow") == 2 then
           crow.output[i]()
         end
-        if params:get(i .. "_send_midi") == 2 then
-          m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-          note_off_queue[i] = 1
-        end
+        send_midi_note_on(i)
       end
     else
       if note_off_queue[i] == 1 then
@@ -243,10 +246,7 @@ local function trig()
           if i <= 4 and params:get(i .. "_send_crow") == 2 then
             crow.output[i]()
           end
-          if params:get(i .. "_send_midi") == 2 then
-            m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-            note_off_queue[i] = 1
-          end
+          send_midi_note_on(i)
         else break end
       else
         if note_off_queue[i] == 1 then
@@ -262,10 +262,7 @@ local function trig()
           if i <= 4 and params:get(i .. "_send_crow") == 2 then
             crow.output[i]()
           end
-          if params:get(i .. "_send_midi") == 2 then
-            m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-            note_off_queue[i] = 1
-          end
+          send_midi_note_on(i)
         else break end
       else
         if note_off_queue[i] == 1 then
@@ -282,10 +279,7 @@ local function trig()
           if i <= 4 and params:get(i .. "_send_crow") == 2 then
             crow.output[i]()
           end
-          if params:get(i .. "_send_midi") == 2 then 
-            m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-            note_off_queue[i] = 1
-          end
+          send_midi_note_on(i)
         else break end
       else
         if note_off_queue[i] == 1 then
@@ -301,10 +295,7 @@ local function trig()
           if i <= 4 and params:get(i .. "_send_crow") == 2 then
             crow.output[i]()
           end
-          if params:get(i.."_send_midi") == 2 then
-            m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-            note_off_queue[i] = 1
-          end
+          send_midi_note_on(i)
         else break end
       else
         if note_off_queue[i] == 1 then
@@ -322,10 +313,7 @@ local function trig()
           if i <= 4 and params:get(i .. "_send_crow") == 2 then
             crow.output[i]()
           end
-          if params:get(i .. "_send_midi") == 2 then
-            m:note_on(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-            note_off_queue[i] = 1
-          end
+          send_midi_note_on(i)
           if note_off_queue[i] == 1 then
             m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
             note_off_queue[i] = 0

--- a/foulplay.lua
+++ b/foulplay.lua
@@ -220,6 +220,13 @@ local function send_midi_note_on(i)
   end
 end
 
+local function send_midi_note_off(i)
+  if note_off_queue[i] == 1 then
+    m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
+    note_off_queue[i] = 0
+  end
+end
+
 local function trig()
   -- mute state is ignored for trigger logics
   for i, t in ipairs(memory_cell[current_mem_cell]) do
@@ -233,10 +240,7 @@ local function trig()
         send_midi_note_on(i)
       end
     else
-      if note_off_queue[i] == 1 then
-        m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-        note_off_queue[i] = 0
-      end
+      send_midi_note_off(i)
     end
     -- logical and
     if t.trig_logic == 1 then
@@ -249,10 +253,7 @@ local function trig()
           send_midi_note_on(i)
         else break end
       else
-        if note_off_queue[i] == 1 then
-          m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-          note_off_queue[i] = 0
-        end
+        send_midi_note_off(i)
       end
     -- logical or
     elseif t.trig_logic == 2 then
@@ -265,10 +266,7 @@ local function trig()
           send_midi_note_on(i)
         else break end
       else
-        if note_off_queue[i] == 1 then
-          m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-          note_off_queue[i] = 0
-        end
+        send_midi_note_off(i)
       end
     -- logical nand
     elseif t.trig_logic == 3 then
@@ -282,10 +280,7 @@ local function trig()
           send_midi_note_on(i)
         else break end
       else
-        if note_off_queue[i] == 1 then
-          m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-          note_off_queue[i] = 0
-        end
+        send_midi_note_off(i)
       end
     -- logical nor
     elseif t.trig_logic == 4 then
@@ -298,10 +293,7 @@ local function trig()
           send_midi_note_on(i)
         else break end
       else
-        if note_off_queue[i] == 1 then
-          m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-          note_off_queue[i] = 0
-        end
+        send_midi_note_off(i)
       end
     -- logical xor
     elseif t.trig_logic == 5 then
@@ -314,10 +306,7 @@ local function trig()
             crow.output[i]()
           end
           send_midi_note_on(i)
-          if note_off_queue[i] == 1 then
-            m:note_off(params:get(i.."_midi_note"), 100, params:get(i.."_midi_chan"))
-            note_off_queue[i] = 0
-          end
+          send_midi_note_off(i)
         end
       else break end
     end

--- a/foulplay.lua
+++ b/foulplay.lua
@@ -101,6 +101,7 @@ er = require 'er'
 
 engine.name = 'Ack'
 local ack = require 'ack/lib/ack'
+local MusicUtil = require "musicutil"
 
 local g = grid.connect()
 local m = midi.connect()
@@ -313,6 +314,12 @@ local function trig()
   end
 end
 
+local function midi_note_formatter(param)
+  note_number = param:get()
+  note_name = MusicUtil.note_num_to_name(note_number, true)
+  return note_number.." ["..note_name.."]"
+end
+
 function init()
   for i=1, 8 do reer(i) end
 
@@ -323,7 +330,7 @@ function init()
     ack.add_channel_params(i)
     params:add_option(i.."_send_midi", i..": send midi", {"no", "yes"}, 1)
     params:add_number(i.."_midi_chan", i..": midi chan", 1, 16, 1)
-    params:add_number(i.."_midi_note", i..": midi note", 0, 127, 0)
+    params:add_number(i.."_midi_note", i..": midi note", 0, 127, 0, midi_note_formatter)
   end
   params:add_separator('crow sends')
   for i = 1, 8 do


### PR DESCRIPTION
After 2 preparatory refactoring commits, this PR makes a few small improvements to the MIDI send features of Foulplay:

- 0f9f85 adds the note name, e.g `C3` after the note number in the parameter menu
- 2785e1 makes the default note `C3`
- 1a779f allows the MIDI device/port to be selected on a per-track basis

See the individual commit messages for more details.

Thanks so much for Foulplay @justmat - I really enjoy using it. Hopefully these changes are generic enough to be useful to other people. 

 